### PR TITLE
Return data.response on http RPC call

### DIFF
--- a/src/rpc.js
+++ b/src/rpc.js
@@ -61,7 +61,7 @@ class Client extends EventEmitter {
       params: args
     }).then(function ({ data }) {
       if (data.error) throw Error(data.error)
-      return data
+      return data.result
     }, function (err) {
       throw Error(err)
     })


### PR DESCRIPTION
Hi Matt
I got some errors when using your library via HTTP. Seems like returning data.response when using the HTTP RPC fixes that.