### PR TITLE
Return a readable error message on rpc error.

### DIFF
--- a/src/rpc.js
+++ b/src/rpc.js
@@ -60,7 +60,7 @@ class Client extends EventEmitter {
       url: this.uri + method,
       params: args
     }).then(function ({ data }) {
-      if (data.error) throw Error(data.error)
+      if (data.error) throw Error(JSON.stringify(data.error));
       return data
     }, function (err) {
       throw Error(err)


### PR DESCRIPTION
It used to look like:
```
      Error: [object Object]
```
Now it looks like:
```
      Error: {"code":-32602,"message":"Invalid params","data":"Error converting http params to arguments: invalid character '/' looking for beginning of value"}
```

This is a big help for debugging....